### PR TITLE
Fix Epel version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Based on the work done by Eric Wolfe and Charles Duffy on the yumrepo cookbook. 
 Changes
 =======
 
+## v0.5.3:
+
+* Fix epel version from 6-5 to 6-7
+
 ## v0.5.2:
 
 * [COOK-825] - epel and ius `remote_file` should notify the `rpm_package` to install

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,7 +24,7 @@ default[:yum][:installonlypkgs]
 
 default['yum']['epel_release'] = case node['platform_version'].to_i
                                   when 6
-                                    "6-5"
+                                    "6-7"
                                   when 5
                                     "5-4"
                                   when 4

--- a/metadata.rb
+++ b/metadata.rb
@@ -2,7 +2,7 @@ maintainer        "Opscode, Inc."
 maintainer_email  "cookbooks@opscode.com"
 license           "Apache 2.0"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           "0.5.2"
+version           "0.5.3"
 recipe            "yum", "Runs 'yum update' during compile phase"
 recipe            "yum::yum", "manages yum configuration"
 


### PR DESCRIPTION
Fixed EPEL version to 6-7 instead of 6-5 since I was getting "Not Found" errors.

For full bug text, see oc-yum ticket #1 on github.com/cookbooks/oc-yum
